### PR TITLE
Add delay to ensure server.log file exists

### DIFF
--- a/charts/epi/Chart.yaml
+++ b/charts/epi/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.7.9
+version: 0.7.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/epi/README.md
+++ b/charts/epi/README.md
@@ -1,6 +1,6 @@
 # epi
 
-![Version: 0.7.9](https://img.shields.io/badge/Version-0.7.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0-rc28](https://img.shields.io/badge/AppVersion-3.0.0--rc28-informational?style=flat-square)
+![Version: 0.7.10](https://img.shields.io/badge/Version-0.7.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0-rc28](https://img.shields.io/badge/AppVersion-3.0.0--rc28-informational?style=flat-square)
 
 A Helm chart for Pharma Ledger epi (electronic product information) application
 
@@ -158,7 +158,7 @@ It is recommended to put non-sensitive configuration values in an configuration 
 2. Install via helm to namespace `default`
 
     ```bash
-    helm upgrade my-release-name pharmaledgerassoc/epi --version=0.7.9 \
+    helm upgrade my-release-name pharmaledgerassoc/epi --version=0.7.10 \
         --install \
         --values my-config.yaml \
     ```
@@ -366,7 +366,7 @@ Run `helm upgrade --helm` for full list of options.
     You can install into other namespace than `default` by setting the `--namespace` parameter, e.g.
 
     ```bash
-    helm upgrade my-release-name pharmaledgerassoc/epi --version=0.7.9 \
+    helm upgrade my-release-name pharmaledgerassoc/epi --version=0.7.10 \
         --install \
         --namespace=my-namespace \
         --values my-config.yaml \
@@ -377,7 +377,7 @@ Run `helm upgrade --helm` for full list of options.
     Provide the `--wait` argument and time to wait (default is 5 minutes) via `--timeout`
 
     ```bash
-    helm upgrade my-release-name pharmaledgerassoc/epi --version=0.7.9 \
+    helm upgrade my-release-name pharmaledgerassoc/epi --version=0.7.10 \
         --install \
         --wait --timeout=600s \
         --values my-config.yaml \

--- a/charts/epi/templates/job-builder.yaml
+++ b/charts/epi/templates/job-builder.yaml
@@ -89,6 +89,9 @@ spec:
             echo "=======> Starting application in background process ..."
             export ENABLE_SSO=false
             npm run server > server.log 2>&1 &
+            until [ -f server.log ]; do
+              sleep 1
+            done
             tail -f server.log &
             server_pid=$
             echo "=======> Application running in background with PID=$server_pid"


### PR DESCRIPTION
The code modification introduces a delay in the continuous-integration script until the server.log file is generated and ready for use. This important step ensures the script does not fail or halt operation due to the absence of the server.log file after starting the server in a background process.